### PR TITLE
Fix use of mint in working groups

### DIFF
--- a/runtime-modules/content-working-group/src/lib.rs
+++ b/runtime-modules/content-working-group/src/lib.rs
@@ -192,7 +192,6 @@ pub static MSG_FULL_CURATOR_OPENING_APPLICATION_NOT_ACTIVE: &str = "ApplicationN
 pub static MSG_FILL_CURATOR_OPENING_INVALID_NEXT_PAYMENT_BLOCK: &str =
     "Reward policy has invalid next payment block number";
 pub static MSG_FILL_CURATOR_OPENING_MINT_DOES_NOT_EXIST: &str = "Working group mint does not exist";
-pub static MSG_FILL_CURATOR_OPENING_MINT_NOT_SET: &str = "Working group mint not set";
 pub static MSG_FILL_CURATOR_OPENING_APPLICATION_FOR_WRONG_OPENING: &str =
     "Applications not for opening";
 // Errors for `withdraw_curator_application`
@@ -1469,13 +1468,10 @@ decl_module! {
 
             // Ensure a mint exists if lead is providing a reward for positions being filled
             let create_reward_settings = if let Some(policy) = reward_policy {
-                // check the value of the mint is actually set before reading it or we will
-                // read a value 0 and possibly use the wrong mint if it exists.
-                ensure!(<Mint<T>>::exists(), MSG_FILL_CURATOR_OPENING_MINT_NOT_SET);
-
                 // A reward will need to be created so ensure our configured mint exists
                 let mint_id = Self::mint();
 
+                // Technically this is a bug-check and should not be here.
                 ensure!(<minting::Mints<T>>::exists(mint_id), MSG_FILL_CURATOR_OPENING_MINT_DOES_NOT_EXIST);
 
                 // Make sure valid parameters are selected for next payment at block number
@@ -1985,7 +1981,7 @@ decl_module! {
         ) {
             ensure_root(origin)?;
 
-            ensure!(<Mint<T>>::exists(), MSG_FILL_CURATOR_OPENING_MINT_NOT_SET);
+            ensure!(<Mint<T>>::exists(), MSG_FILL_CURATOR_OPENING_MINT_DOES_NOT_EXIST);
 
             let mint_id = Self::mint();
 

--- a/runtime-modules/content-working-group/src/lib.rs
+++ b/runtime-modules/content-working-group/src/lib.rs
@@ -192,6 +192,7 @@ pub static MSG_FULL_CURATOR_OPENING_APPLICATION_NOT_ACTIVE: &str = "ApplicationN
 pub static MSG_FILL_CURATOR_OPENING_INVALID_NEXT_PAYMENT_BLOCK: &str =
     "Reward policy has invalid next payment block number";
 pub static MSG_FILL_CURATOR_OPENING_MINT_DOES_NOT_EXIST: &str = "Working group mint does not exist";
+pub static MSG_FILL_CURATOR_OPENING_MINT_NOT_SET: &str = "Working group mint not set";
 pub static MSG_FILL_CURATOR_OPENING_APPLICATION_FOR_WRONG_OPENING: &str =
     "Applications not for opening";
 // Errors for `withdraw_curator_application`
@@ -1468,6 +1469,10 @@ decl_module! {
 
             // Ensure a mint exists if lead is providing a reward for positions being filled
             let create_reward_settings = if let Some(policy) = reward_policy {
+                // check the value of the mint is actually set before reading it or we will
+                // read a value 0 and possibly use the wrong mint if it exists.
+                ensure!(<Mint<T>>::exists(), MSG_FILL_CURATOR_OPENING_MINT_NOT_SET);
+
                 // A reward will need to be created so ensure our configured mint exists
                 let mint_id = Self::mint();
 
@@ -1979,6 +1984,8 @@ decl_module! {
             new_capacity: minting::BalanceOf<T>
         ) {
             ensure_root(origin)?;
+
+            ensure!(<Mint<T>>::exists(), MSG_FILL_CURATOR_OPENING_MINT_NOT_SET);
 
             let mint_id = Self::mint();
 

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -230,9 +230,6 @@ decl_error! {
         /// Slash amount should be greater than zero.
         StakingErrorSlashAmountShouldBeGreaterThanZero,
 
-        /// Working group mint is not set.
-        WorkingGroupMintIsNotSet,
-
         /// Cannot find mint in the minting module.
         CannotFindMint,
 

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -747,13 +747,10 @@ decl_module! {
 
             // Ensure a mint exists if lead is providing a reward for positions being filled
             let create_reward_settings = if let Some(policy) = reward_policy {
-                // check the value of the mint is actually set before reading it or we will
-                // read a value 0 and possibly use the wrong mint if it exists.
-                ensure!(<Mint<T, I>>::exists(), Error::WorkingGroupMintIsNotSet);
-
                 // A reward will need to be created so ensure our configured mint exists
                 let mint_id = Self::mint();
 
+                // Technically this is a bug-check and should not be here.
                 ensure!(<minting::Mints<T>>::exists(mint_id), Error::FillWorkerOpeningMintDoesNotExist);
 
                 // Make sure valid parameters are selected for next payment at block number
@@ -970,10 +967,9 @@ decl_module! {
         ) {
             ensure_root(origin)?;
 
-            ensure!(<Mint<T, I>>::exists(), Error::WorkingGroupMintIsNotSet);
-
             let mint_id = Self::mint();
 
+            // Technically this is a bug-check and should not be here.
             ensure!(<minting::Mints<T>>::exists(mint_id), Error::CannotFindMint);
 
             // Mint must exist - it is set at genesis or migration.

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -219,15 +219,6 @@ impl UnsetLeadFixture {
     }
 }
 
-pub fn remove_mint() {
-    let mint_id = <crate::Mint<Test, TestWorkingGroupInstance>>::get();
-    // Killing the storage value will make the mintid returned to be 0
-    // which may infact exist in the minting module, so doing
-    // a check if the working group's module mint exists could return a false-postive
-    <crate::Mint<Test, TestWorkingGroupInstance>>::kill();
-    <minting::Module<Test>>::remove_mint(mint_id);
-}
-
 pub fn set_mint_id(mint_id: u64) {
     <crate::Mint<Test, TestWorkingGroupInstance>>::put(mint_id);
 }

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -221,8 +221,10 @@ impl UnsetLeadFixture {
 
 pub fn remove_mint() {
     let mint_id = <crate::Mint<Test, TestWorkingGroupInstance>>::get();
+    // Killing the storage value will make the mintid returned to be 0
+    // which may infact exist in the minting module, so doing
+    // a check if the working group's module mint exists could return a false-postive
     <crate::Mint<Test, TestWorkingGroupInstance>>::kill();
-
     <minting::Module<Test>>::remove_mint(mint_id);
 }
 

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -921,20 +921,21 @@ fn fill_worker_opening_fails_with_invalid_reward_policy() {
                     payout_interval: None,
                 });
 
-        remove_mint(); //removes default mintx
-        fill_worker_opening_fixture.call_and_assert(Err(Error::FillWorkerOpeningMintDoesNotExist));
+        remove_mint(); //removes default mint
+        fill_worker_opening_fixture.call_and_assert(Err(Error::WorkingGroupMintIsNotSet));
 
-        set_mint_id(22);
+        set_mint_id(create_mint());
 
         let fill_worker_opening_fixture =
             FillWorkerOpeningFixture::default_for_ids(opening_id, vec![application_id])
                 .with_reward_policy(RewardPolicy {
                     amount_per_payout: 10000,
+                    // Invalid next payment at block zero
                     next_payment_at_block: 0,
                     payout_interval: None,
                 });
         fill_worker_opening_fixture
-            .call_and_assert(Err(Error::FullWorkerOpeningOpeningNotInReviewPeriodStage));
+            .call_and_assert(Err(Error::FillWorkerOpeningInvalidNextPaymentBlock));
     });
 }
 

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -917,19 +917,6 @@ fn fill_worker_opening_fails_with_invalid_reward_policy() {
             FillWorkerOpeningFixture::default_for_ids(opening_id, vec![application_id])
                 .with_reward_policy(RewardPolicy {
                     amount_per_payout: 10000,
-                    next_payment_at_block: 100,
-                    payout_interval: None,
-                });
-
-        remove_mint(); //removes default mint
-        fill_worker_opening_fixture.call_and_assert(Err(Error::WorkingGroupMintIsNotSet));
-
-        set_mint_id(create_mint());
-
-        let fill_worker_opening_fixture =
-            FillWorkerOpeningFixture::default_for_ids(opening_id, vec![application_id])
-                .with_reward_policy(RewardPolicy {
-                    amount_per_payout: 10000,
                     // Invalid next payment at block zero
                     next_payment_at_block: 0,
                     payout_interval: None,
@@ -1587,18 +1574,6 @@ fn set_working_group_mint_capacity_succeeds() {
 
         let mint = <minting::Module<Test>>::mints(mint_id);
         assert_eq!(mint.capacity(), capacity);
-    });
-}
-
-#[test]
-fn set_working_group_mint_capacity_fails_with_not_set_working_group_mint() {
-    build_test_externalities().execute_with(|| {
-        remove_mint(); //removes default mint
-
-        let capacity = 15000;
-        let result = TestWorkingGroup::set_mint_capacity(RawOrigin::Root.into(), capacity);
-
-        assert_eq!(result, Err(Error::WorkingGroupMintIsNotSet));
     });
 }
 


### PR DESCRIPTION
- Ensure mint exists before filling opening if a reward policy is used
  because mutation of filled positions can happen followed by a failed check for the mint.
- ~~check mint value exists before reading from storage.~~ decided against doing this "bug-check"
- fix `fill_worker_opening_fails_with_invalid_reward_policy()` working-group test