### PR TITLE
Conditional compilation for the runtime proposals parameters.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,8 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "lazy_static",
+ "lite-json",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -2339,6 +2341,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -2732,6 +2737,24 @@ dependencies = [
  "failure",
  "nalgebra",
  "statrs",
+]
+
+[[package]]
+name = "lite-json"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0460d985423a026b4d9b828a7c6eed1bcf606f476322f3f9b507529686a61715"
+dependencies = [
+ "lite-parser",
+]
+
+[[package]]
+name = "lite-parser"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c50092e40e0ccd1bf2015a10333fde0502ff95b832b0895dc1ca0d7ac6c52f6"
+dependencies = [
+ "paste",
 ]
 
 [[package]]
@@ -7502,9 +7525,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -340,10 +340,6 @@ pub fn testnet_genesis(
         versioned_store_permissions: Some(versioned_store_permissions_config),
         content_wg: Some(content_working_group_config),
         proposals_codex: Some(ProposalsCodexConfig {
-            set_validator_count_proposal_voting_period: cpcp
-                .set_validator_count_proposal_voting_period,
-            set_validator_count_proposal_grace_period: cpcp
-                .set_validator_count_proposal_grace_period,
             runtime_upgrade_proposal_voting_period: cpcp.runtime_upgrade_proposal_voting_period,
             runtime_upgrade_proposal_grace_period: cpcp.runtime_upgrade_proposal_grace_period,
             text_proposal_voting_period: cpcp.text_proposal_voting_period,

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -129,6 +129,11 @@ pub trait Trait:
 
     /// Encodes the proposal usint its details
     type ProposalEncoder: ProposalEncoder<Self>;
+
+    /// 'Set validator count' proposal parameters
+    type SetValidatorCountProposalParameters: Get<
+        ProposalParameters<Self::BlockNumber, BalanceOf<Self>>,
+    >;
 }
 
 /// Balance alias for GovernanceCurrency from `common` module. TODO: replace with BalanceOf
@@ -218,14 +223,6 @@ decl_storage! {
         /// Map proposal id to proposal details
         pub ProposalDetailsByProposalId get(fn proposal_details_by_proposal_id):
             map hasher(blake2_128_concat) T::ProposalId => ProposalDetailsOf<T>;
-
-        /// Voting period for the 'set validator count' proposal
-        pub SetValidatorCountProposalVotingPeriod get(fn set_validator_count_proposal_voting_period)
-            config(): T::BlockNumber;
-
-        /// Grace period for the 'set validator count' proposal
-        pub SetValidatorCountProposalGracePeriod get(fn set_validator_count_proposal_grace_period)
-            config(): T::BlockNumber;
 
         /// Voting period for the 'runtime upgrade' proposal
         pub RuntimeUpgradeProposalVotingPeriod get(fn runtime_upgrade_proposal_voting_period)
@@ -464,7 +461,7 @@ decl_module! {
                 description,
                 staking_account_id,
                 proposal_details: proposal_details.clone(),
-                proposal_parameters: proposal_types::parameters::set_validator_count_proposal::<T>(),
+                proposal_parameters: T::SetValidatorCountProposalParameters::get(),
                 proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
                 exact_execution_block,
             };
@@ -840,89 +837,6 @@ impl<T: Trait> Module<T> {
         <ProposalDetailsByProposalId<T>>::insert(proposal_id, params.proposal_details);
 
         Ok(())
-    }
-
-    /// Sets config values for the proposals.
-    /// Should be called on the migration to the new runtime version.
-    pub fn set_config_values(p: ProposalsConfigParameters) {
-        <SetValidatorCountProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.set_validator_count_proposal_voting_period,
-        ));
-        <SetValidatorCountProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.set_validator_count_proposal_grace_period,
-        ));
-        <RuntimeUpgradeProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.runtime_upgrade_proposal_voting_period,
-        ));
-        <RuntimeUpgradeProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.runtime_upgrade_proposal_grace_period,
-        ));
-        <TextProposalVotingPeriod<T>>::put(T::BlockNumber::from(p.text_proposal_voting_period));
-        <TextProposalGracePeriod<T>>::put(T::BlockNumber::from(p.text_proposal_grace_period));
-        <SpendingProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.spending_proposal_voting_period,
-        ));
-        <SpendingProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.spending_proposal_grace_period,
-        ));
-        <AddWorkingGroupOpeningProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.add_working_group_opening_proposal_voting_period,
-        ));
-        <AddWorkingGroupOpeningProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.add_working_group_opening_proposal_grace_period,
-        ));
-        <BeginReviewWorkingGroupLeaderApplicationsProposalVotingPeriod<T>>::put(
-            T::BlockNumber::from(
-                p.begin_review_working_group_leader_applications_proposal_voting_period,
-            ),
-        );
-        <BeginReviewWorkingGroupLeaderApplicationsProposalGracePeriod<T>>::put(
-            T::BlockNumber::from(
-                p.begin_review_working_group_leader_applications_proposal_grace_period,
-            ),
-        );
-        <FillWorkingGroupLeaderOpeningProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.fill_working_group_leader_opening_proposal_voting_period,
-        ));
-        <FillWorkingGroupLeaderOpeningProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.fill_working_group_leader_opening_proposal_grace_period,
-        ));
-        <SetWorkingGroupMintCapacityProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.set_working_group_mint_capacity_proposal_voting_period,
-        ));
-        <SetWorkingGroupMintCapacityProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.set_working_group_mint_capacity_proposal_grace_period,
-        ));
-        <DecreaseWorkingGroupLeaderStakeProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.decrease_working_group_leader_stake_proposal_voting_period,
-        ));
-        <DecreaseWorkingGroupLeaderStakeProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.decrease_working_group_leader_stake_proposal_grace_period,
-        ));
-        <SlashWorkingGroupLeaderStakeProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.slash_working_group_leader_stake_proposal_voting_period,
-        ));
-        <SlashWorkingGroupLeaderStakeProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.slash_working_group_leader_stake_proposal_grace_period,
-        ));
-        <SetWorkingGroupLeaderRewardProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.set_working_group_leader_reward_proposal_voting_period,
-        ));
-        <SetWorkingGroupLeaderRewardProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.set_working_group_leader_reward_proposal_grace_period,
-        ));
-        <TerminateWorkingGroupLeaderRoleProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.terminate_working_group_leader_role_proposal_voting_period,
-        ));
-        <TerminateWorkingGroupLeaderRoleProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.terminate_working_group_leader_role_proposal_grace_period,
-        ));
-        <AmendConstitutionProposalVotingPeriod<T>>::put(T::BlockNumber::from(
-            p.amend_constitution_proposal_voting_period,
-        ));
-        <AmendConstitutionProposalGracePeriod<T>>::put(T::BlockNumber::from(
-            p.amend_constitution_proposal_grace_period,
-        ));
     }
 }
 

--- a/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
@@ -1,20 +1,5 @@
 use crate::{BalanceOf, Module, ProposalParameters};
 
-// Proposal parameters for the 'Set validator count' proposal
-pub(crate) fn set_validator_count_proposal<T: crate::Trait>(
-) -> ProposalParameters<T::BlockNumber, BalanceOf<T>> {
-    ProposalParameters {
-        voting_period: <Module<T>>::set_validator_count_proposal_voting_period(),
-        grace_period: <Module<T>>::set_validator_count_proposal_grace_period(),
-        approval_quorum_percentage: 66,
-        approval_threshold_percentage: 80,
-        slashing_quorum_percentage: 60,
-        slashing_threshold_percentage: 80,
-        required_stake: Some(<BalanceOf<T>>::from(100_000_u32)),
-        constitutionality: 1,
-    }
-}
-
 // Proposal parameters for the upgrade runtime proposal
 pub(crate) fn runtime_upgrade_proposal<T: crate::Trait>(
 ) -> ProposalParameters<T::BlockNumber, BalanceOf<T>> {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -12,7 +12,7 @@ use sp_runtime::{
 use sp_staking::SessionIndex;
 pub use system;
 
-use crate::{ProposalDetailsOf, ProposalEncoder};
+use crate::{ProposalDetailsOf, ProposalEncoder, ProposalParameters};
 use proposals_engine::VotersParameters;
 use sp_runtime::testing::TestXt;
 
@@ -254,11 +254,30 @@ impl staking::SessionInterface<u64> for Test {
     }
 }
 
+parameter_types! {
+    pub SetValidatorCountProposalParameters: ProposalParameters<u64, u64> = set_validator_count_proposal();
+}
+
+// Proposal parameters for the 'Set validator count' proposal
+pub(crate) fn set_validator_count_proposal() -> ProposalParameters<u64, u64> {
+    ProposalParameters {
+        voting_period: 43200,
+        grace_period: 0,
+        approval_quorum_percentage: 66,
+        approval_threshold_percentage: 80,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(100_000),
+        constitutionality: 1,
+    }
+}
+
 impl crate::Trait for Test {
     type TextProposalMaxLength = TextProposalMaxLength;
     type RuntimeUpgradeWasmProposalMaxLength = RuntimeUpgradeWasmProposalMaxLength;
     type MembershipOriginValidator = ();
     type ProposalEncoder = ();
+    type SetValidatorCountProposalParameters = SetValidatorCountProposalParameters;
 }
 
 impl ProposalEncoder<Test> for () {

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -10,7 +10,6 @@ use hiring::ActivateOpeningAt;
 use proposals_engine::ProposalParameters;
 use working_group::OpeningPolicyCommitment;
 
-use crate::proposal_types::ProposalsConfigParameters;
 use crate::*;
 use crate::{Error, ProposalDetails};
 pub use mock::*;
@@ -373,9 +372,7 @@ fn create_set_validator_count_proposal_common_checks_succeed() {
                     None,
                 )
             },
-            proposal_parameters: crate::proposal_types::parameters::set_validator_count_proposal::<
-                Test,
-            >(),
+            proposal_parameters: <Test as crate::Trait>::SetValidatorCountProposalParameters::get(),
             proposal_details: ProposalDetails::SetValidatorCount(4),
         };
         proposal_fixture.check_all();
@@ -409,115 +406,6 @@ fn create_set_validator_count_proposal_failed_with_invalid_validator_count() {
                 None,
             ),
             Err(Error::<Test>::InvalidValidatorCount.into())
-        );
-    });
-}
-
-#[test]
-fn set_default_proposal_parameters_succeeded() {
-    initial_test_ext().execute_with(|| {
-        let p = ProposalsConfigParameters::default();
-
-        // nothing is set
-        assert_eq!(<SetValidatorCountProposalVotingPeriod<Test>>::get(), 0);
-
-        ProposalCodex::set_config_values(p);
-
-        assert_eq!(
-            <SetValidatorCountProposalVotingPeriod<Test>>::get(),
-            p.set_validator_count_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <SetValidatorCountProposalGracePeriod<Test>>::get(),
-            p.set_validator_count_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <RuntimeUpgradeProposalVotingPeriod<Test>>::get(),
-            p.runtime_upgrade_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <RuntimeUpgradeProposalGracePeriod<Test>>::get(),
-            p.runtime_upgrade_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <TextProposalVotingPeriod<Test>>::get(),
-            p.text_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <TextProposalGracePeriod<Test>>::get(),
-            p.text_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <SpendingProposalVotingPeriod<Test>>::get(),
-            p.spending_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <SpendingProposalGracePeriod<Test>>::get(),
-            p.spending_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <AddWorkingGroupOpeningProposalVotingPeriod<Test>>::get(),
-            p.add_working_group_opening_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <AddWorkingGroupOpeningProposalGracePeriod<Test>>::get(),
-            p.add_working_group_opening_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <BeginReviewWorkingGroupLeaderApplicationsProposalVotingPeriod<Test>>::get(),
-            p.begin_review_working_group_leader_applications_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <BeginReviewWorkingGroupLeaderApplicationsProposalGracePeriod<Test>>::get(),
-            p.begin_review_working_group_leader_applications_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <FillWorkingGroupLeaderOpeningProposalVotingPeriod<Test>>::get(),
-            p.fill_working_group_leader_opening_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <FillWorkingGroupLeaderOpeningProposalGracePeriod<Test>>::get(),
-            p.fill_working_group_leader_opening_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <SetWorkingGroupMintCapacityProposalVotingPeriod<Test>>::get(),
-            p.set_working_group_mint_capacity_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <SetWorkingGroupMintCapacityProposalGracePeriod<Test>>::get(),
-            p.set_working_group_mint_capacity_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <DecreaseWorkingGroupLeaderStakeProposalVotingPeriod<Test>>::get(),
-            p.decrease_working_group_leader_stake_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <DecreaseWorkingGroupLeaderStakeProposalGracePeriod<Test>>::get(),
-            p.decrease_working_group_leader_stake_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <SlashWorkingGroupLeaderStakeProposalVotingPeriod<Test>>::get(),
-            p.slash_working_group_leader_stake_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <SlashWorkingGroupLeaderStakeProposalGracePeriod<Test>>::get(),
-            p.slash_working_group_leader_stake_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <SetWorkingGroupLeaderRewardProposalVotingPeriod<Test>>::get(),
-            p.set_working_group_leader_reward_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <SetWorkingGroupLeaderRewardProposalGracePeriod<Test>>::get(),
-            p.set_working_group_leader_reward_proposal_grace_period as u64
-        );
-        assert_eq!(
-            <TerminateWorkingGroupLeaderRoleProposalVotingPeriod<Test>>::get(),
-            p.terminate_working_group_leader_role_proposal_voting_period as u64
-        );
-        assert_eq!(
-            <TerminateWorkingGroupLeaderRoleProposalGracePeriod<Test>>::get(),
-            p.terminate_working_group_leader_role_proposal_grace_period as u64
         );
     });
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,6 +9,8 @@ version = '7.6.0'
 [dependencies]
 # Third-party dependencies
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
+lazy_static = {version = "1.4.0", features = ["spin_no_std"] }
+lite-json = { version = '0.1.3', default-features = false}
 codec = { package = 'parity-scale-codec', version = '1.3.1', default-features = false, features = ['derive'] }
 
 # Substrate primitives

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,6 +52,10 @@ use storage::data_object_storage_registry;
 
 // Node dependencies
 pub use common;
+pub use content_directory;
+pub use content_directory::{
+    HashedTextMaxLength, InputValidationLengthConstraint, MaxNumber, TextMaxLength, VecMaxLength,
+};
 pub use content_working_group as content_wg;
 pub use forum;
 pub use governance::election_params::ElectionParameters;
@@ -60,15 +64,11 @@ pub use membership;
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_staking::StakerStatus;
 pub use proposals_codex::ProposalsConfigParameters;
+pub use proposals_engine::ProposalParameters;
 pub use storage::{data_directory, data_object_type_registry};
 pub use versioned_store;
 pub use versioned_store_permissions;
 pub use working_group;
-
-pub use content_directory;
-pub use content_directory::{
-    HashedTextMaxLength, InputValidationLengthConstraint, MaxNumber, TextMaxLength, VecMaxLength,
-};
 
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -598,6 +598,21 @@ impl proposals_discussion::Trait for Runtime {
 parameter_types! {
     pub const TextProposalMaxLength: u32 = 5_000;
     pub const RuntimeUpgradeWasmProposalMaxLength: u32 = 3_000_000;
+    pub SetValidatorCountProposalParameters: ProposalParameters<BlockNumber, Balance> = set_validator_count_proposal();
+}
+
+// Proposal parameters for the 'Set validator count' proposal
+pub(crate) fn set_validator_count_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 43200u32,
+        grace_period: 0u32,
+        approval_quorum_percentage: 66,
+        approval_threshold_percentage: 80,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(100_000_u128),
+        constitutionality: 1,
+    }
 }
 
 impl proposals_codex::Trait for Runtime {
@@ -605,6 +620,7 @@ impl proposals_codex::Trait for Runtime {
     type TextProposalMaxLength = TextProposalMaxLength;
     type RuntimeUpgradeWasmProposalMaxLength = RuntimeUpgradeWasmProposalMaxLength;
     type ProposalEncoder = ExtrinsicProposalEncoder;
+    type SetValidatorCountProposalParameters = SetValidatorCountProposalParameters;
 }
 
 impl constitution::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,9 +16,13 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 mod constants;
 mod integration;
 pub mod primitives;
+mod proposals_configuration;
 mod runtime_api;
 #[cfg(test)]
 mod tests; // Runtime integration tests
+
+#[macro_use]
+extern crate lazy_static; // for proposals_configuration module
 
 use frame_support::traits::{KeyOwnerProofSystem, LockIdentifier};
 use frame_support::weights::{
@@ -43,6 +47,7 @@ use system::EnsureRoot;
 
 pub use constants::*;
 pub use primitives::*;
+pub use proposals_configuration::*;
 pub use runtime_api::*;
 
 use integration::proposals::{CouncilManager, ExtrinsicProposalEncoder, MembershipOriginValidator};
@@ -598,21 +603,6 @@ impl proposals_discussion::Trait for Runtime {
 parameter_types! {
     pub const TextProposalMaxLength: u32 = 5_000;
     pub const RuntimeUpgradeWasmProposalMaxLength: u32 = 3_000_000;
-    pub SetValidatorCountProposalParameters: ProposalParameters<BlockNumber, Balance> = set_validator_count_proposal();
-}
-
-// Proposal parameters for the 'Set validator count' proposal
-pub(crate) fn set_validator_count_proposal() -> ProposalParameters<BlockNumber, Balance> {
-    ProposalParameters {
-        voting_period: 43200u32,
-        grace_period: 0u32,
-        approval_quorum_percentage: 66,
-        approval_threshold_percentage: 80,
-        slashing_quorum_percentage: 60,
-        slashing_threshold_percentage: 80,
-        required_stake: Some(100_000_u128),
-        constitutionality: 1,
-    }
 }
 
 impl proposals_codex::Trait for Runtime {

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -1,0 +1,15 @@
+use crate::{Balance, BlockNumber, ProposalParameters};
+
+// Proposal parameters for the 'Set validator count' proposal
+pub(crate) fn set_validator_count_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 43200,
+        grace_period: 0,
+        approval_quorum_percentage: 66,
+        approval_threshold_percentage: 80,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(100_000),
+        constitutionality: 1,
+    }
+}

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -1,3 +1,5 @@
+//! This module contains default parameters for the runtime codex proposals.
+
 use crate::{Balance, BlockNumber, ProposalParameters};
 
 // Proposal parameters for the 'Set validator count' proposal

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -45,12 +45,10 @@ fn get_all_proposals_parameters_objects() -> AllProposalsParameters {
 
     json_str
         .map(lite_json::parse_json)
-        .map(|res| {
-            match res {
-                Ok(json) => Some(json),
-                Err(_) => {
-                    panic!("Invalid JSON with proposals parameters provided.");
-                }
+        .map(|res| match res {
+            Ok(json) => Some(json),
+            Err(_) => {
+                panic!("Invalid JSON with proposals parameters provided.");
             }
         })
         .flatten()
@@ -69,11 +67,8 @@ fn get_all_proposals_parameters_objects() -> AllProposalsParameters {
 //         );
 macro_rules! init_proposal_parameter_object {
     ($parameters_object:ident, $jsonObj:expr, $name:ident) => {
-        $parameters_object.$name = create_proposal_parameters_object(
-            $jsonObj,
-            stringify!($name),
-            defaults::$name(),
-        );
+        $parameters_object.$name =
+            create_proposal_parameters_object($jsonObj, stringify!($name), defaults::$name());
     };
 }
 
@@ -123,18 +118,22 @@ macro_rules! init_proposal_parameter_field {
             $jsonObj,
             stringify!($name),
             $default_object.$name.saturated_into(),
-        ).saturated_into();
+        )
+        .saturated_into();
     };
 }
 
 // Helper macro similar to init_proposal_parameter_field but for optional parameters.
 macro_rules! init_proposal_parameter_optional_field {
     ($parameters_object:ident, $jsonObj:expr, $default_object:ident, $name:ident) => {
-        $parameters_object.$name = Some(extract_numeric_parameter(
-            $jsonObj,
-            stringify!($name),
-            $default_object.$name.unwrap_or_default().saturated_into(),
-        ).saturated_into());
+        $parameters_object.$name = Some(
+            extract_numeric_parameter(
+                $jsonObj,
+                stringify!($name),
+                $default_object.$name.unwrap_or_default().saturated_into(),
+            )
+            .saturated_into(),
+        );
     };
 }
 
@@ -147,12 +146,42 @@ fn extract_proposal_parameters(
 
     init_proposal_parameter_field!(proposals_parameters, json_object, defaults, voting_period);
     init_proposal_parameter_field!(proposals_parameters, json_object, defaults, grace_period);
-    init_proposal_parameter_field!(proposals_parameters, json_object, defaults, approval_quorum_percentage);
-    init_proposal_parameter_field!(proposals_parameters, json_object, defaults, approval_threshold_percentage);
-    init_proposal_parameter_field!(proposals_parameters, json_object, defaults, slashing_quorum_percentage);
-    init_proposal_parameter_field!(proposals_parameters, json_object, defaults, slashing_threshold_percentage);
-    init_proposal_parameter_optional_field!(proposals_parameters, json_object, defaults, required_stake);
-    init_proposal_parameter_field!(proposals_parameters, json_object, defaults, constitutionality);
+    init_proposal_parameter_field!(
+        proposals_parameters,
+        json_object,
+        defaults,
+        approval_quorum_percentage
+    );
+    init_proposal_parameter_field!(
+        proposals_parameters,
+        json_object,
+        defaults,
+        approval_threshold_percentage
+    );
+    init_proposal_parameter_field!(
+        proposals_parameters,
+        json_object,
+        defaults,
+        slashing_quorum_percentage
+    );
+    init_proposal_parameter_field!(
+        proposals_parameters,
+        json_object,
+        defaults,
+        slashing_threshold_percentage
+    );
+    init_proposal_parameter_optional_field!(
+        proposals_parameters,
+        json_object,
+        defaults,
+        required_stake
+    );
+    init_proposal_parameter_field!(
+        proposals_parameters,
+        json_object,
+        defaults,
+        constitutionality
+    );
 
     proposals_parameters
 }

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -45,7 +45,14 @@ fn get_all_proposals_parameters_objects() -> AllProposalsParameters {
 
     json_str
         .map(lite_json::parse_json)
-        .map(|res| res.ok())
+        .map(|res| {
+            match res {
+                Ok(json) => Some(json),
+                Err(_) => {
+                    panic!("Invalid JSON with proposals parameters provided.");
+                }
+            }
+        })
         .flatten()
         .map(convert_json_object_to_proposal_parameters)
         .unwrap_or_else(default_parameters)

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -1,0 +1,146 @@
+use crate::{Balance, BlockNumber, ProposalParameters};
+use frame_support::dispatch::Vec;
+use frame_support::parameter_types;
+use frame_support::sp_runtime::SaturatedConversion;
+use lite_json::{JsonObject, JsonValue};
+
+mod defaults;
+#[cfg(test)]
+mod tests;
+
+struct AllProposalsParameters {
+    pub set_validator_count_proposal: ProposalParameters<BlockNumber, Balance>,
+}
+
+// to initialize parameter only once.
+lazy_static! {
+    static ref ALL_PROPOSALS_PARAMETERS: AllProposalsParameters = get_all_proposals_parameters();
+}
+
+parameter_types! {
+    pub SetValidatorCountProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.set_validator_count_proposal;
+}
+
+// Composes AllProposalsParameters object from the JSON string.
+// It gets the JSON string from the environment variable and tries to parse it.
+// On error and any missing values it gets default values.
+fn get_all_proposals_parameters() -> AllProposalsParameters {
+    let json_str: Option<&'static str> = option_env!("ALL_PROPOSALS_PARAMETERS_JSON");
+
+    json_str
+        .map(lite_json::parse_json)
+        .map(|res| res.ok())
+        .flatten()
+        .map(convert_json_object)
+        .unwrap_or_else(default_parameters)
+}
+
+// Tries to extract all proposal parameters from the parsed JSON object.
+fn convert_json_object(json: lite_json::JsonValue) -> AllProposalsParameters {
+    let mut parameters = default_parameters();
+
+    if let lite_json::JsonValue::Object(json_object) = json {
+        parameters.set_validator_count_proposal = create_proposal_parameters_object(
+            json_object,
+            "set_validator_count_proposal",
+            defaults::set_validator_count_proposal(),
+        );
+    }
+
+    parameters
+}
+
+// Tries to create specific ProposalParameters object from the parsed JSON object.
+// Returns default parameters on missing values.
+fn create_proposal_parameters_object(
+    json_object: JsonObject,
+    proposal_name: &'static str,
+    defaults: ProposalParameters<BlockNumber, Balance>,
+) -> ProposalParameters<BlockNumber, Balance> {
+    json_object
+        .iter()
+        .find(|(name_vec, _)| name_vec.eq(&proposal_name.chars().collect::<Vec<_>>()))
+        .map(|(_, params)| extract_proposal_parameters(params, defaults))
+        .unwrap_or(defaults)
+}
+
+// Extracts proposal parameters from the parsed JSON object.
+fn extract_proposal_parameters(
+    json_object: &JsonValue,
+    defaults: ProposalParameters<BlockNumber, Balance>,
+) -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters::<BlockNumber, Balance> {
+        voting_period: extract_parameter(
+            json_object,
+            "voting_period",
+            defaults.voting_period.saturated_into(),
+        )
+        .saturated_into(),
+        grace_period: extract_parameter(
+            json_object,
+            "grace_period",
+            defaults.grace_period.saturated_into(),
+        )
+        .saturated_into(),
+        approval_quorum_percentage: extract_parameter(
+            json_object,
+            "approval_quorum_percentage",
+            defaults.approval_quorum_percentage.saturated_into(),
+        )
+        .saturated_into(),
+        approval_threshold_percentage: extract_parameter(
+            json_object,
+            "approval_threshold_percentage",
+            defaults.approval_threshold_percentage.saturated_into(),
+        )
+        .saturated_into(),
+        slashing_quorum_percentage: extract_parameter(
+            json_object,
+            "slashing_quorum_percentage",
+            defaults.slashing_quorum_percentage.saturated_into(),
+        )
+        .saturated_into(),
+        slashing_threshold_percentage: extract_parameter(
+            json_object,
+            "slashing_threshold_percentage",
+            defaults.slashing_threshold_percentage.saturated_into(),
+        )
+        .saturated_into(),
+        required_stake: Some(
+            extract_parameter(
+                json_object,
+                "required_stake",
+                defaults.required_stake.unwrap_or_default().saturated_into(),
+            )
+            .saturated_into(),
+        ),
+        constitutionality: extract_parameter(
+            json_object,
+            "constitutionality",
+            defaults.constitutionality.saturated_into(),
+        )
+        .saturated_into(),
+    }
+}
+
+// Extracts a specific parameter from the parsed JSON object.
+fn extract_parameter(json_object: &JsonValue, parameter_name: &'static str, default: u128) -> u128 {
+    match json_object {
+        JsonValue::Object(json_object) => json_object
+            .iter()
+            .find(|(name_vec, _)| name_vec.eq(&parameter_name.chars().collect::<Vec<_>>()))
+            .map(|(_, value)| match value {
+                JsonValue::Number(number) => number.integer.saturated_into(),
+                _ => 0u128,
+            })
+            .unwrap_or(default),
+        _ => default,
+    }
+}
+
+// Returns all default proposal parameters.
+fn default_parameters() -> AllProposalsParameters {
+    AllProposalsParameters {
+        set_validator_count_proposal: defaults::set_validator_count_proposal(),
+    }
+}

--- a/runtime/src/proposals_configuration/sample_proposal_parameters.json
+++ b/runtime/src/proposals_configuration/sample_proposal_parameters.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "This is a sample 'Proposal parameters' JSON file to enable conditional runtime compilation.",
+  "set_validator_count_proposal": {
+    "voting_period": 1,
+    "grace_period": 2,
+    "approval_quorum_percentage": 3,
+    "approval_threshold_percentage": 4,
+    "slashing_quorum_percentage": 5,
+    "slashing_threshold_percentage": 6,
+    "required_stake": 7,
+    "constitutionality": 8
+  }
+}

--- a/runtime/src/proposals_configuration/tests.rs
+++ b/runtime/src/proposals_configuration/tests.rs
@@ -1,17 +1,19 @@
 use crate::ProposalParameters;
 
+// Enable during the conditional compilation tests.
+#[ignore]
 #[test]
 fn proposal_parameters_are_initialized() {
     let actual_params = super::SetValidatorCountProposalParameters::get();
     let expected_params = ProposalParameters {
-        voting_period: 43200,
-        grace_period: 0,
-        approval_quorum_percentage: 66,
-        approval_threshold_percentage: 80,
-        slashing_quorum_percentage: 60,
-        slashing_threshold_percentage: 80,
-        required_stake: Some(100_000),
-        constitutionality: 1,
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
     };
 
     assert_eq!(expected_params, actual_params);

--- a/runtime/src/proposals_configuration/tests.rs
+++ b/runtime/src/proposals_configuration/tests.rs
@@ -1,0 +1,18 @@
+use crate::ProposalParameters;
+
+#[test]
+fn proposal_parameters_are_initialized() {
+    let actual_params = super::SetValidatorCountProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 43200,
+        grace_period: 0,
+        approval_quorum_percentage: 66,
+        approval_threshold_percentage: 80,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(100_000),
+        constitutionality: 1,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}


### PR DESCRIPTION
### Summary

We created a separate runtime module(file) In order to be able to pass the proposal parameter constants during the compilation time. The primary goal for the conditional compilation is integration tests. All parameters for the proposal could be set via `ALL_PROPOSALS_PARAMETERS_JSON` environment variable. The value of the variable should be a valid JSON file (a sample file is included in the PR). The PR contains a migration of the single proposal parameter set for demo purposes.

### Comments

- We used `lite-json` crate as "no_std" option for parsing JSON recommended for Substrate. `serde_json` is not 'no_std' ready.  `serder_json_core` library is not working. 
- Tests are ready for the code but disabled (marked `ignore`).