### PR TITLE
Proposals update5 tweak

### DIFF
--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -318,6 +318,9 @@ decl_module! {
         /// Predefined errors
         type Error = Error<T>;
 
+        /// Exports SetValidatorCount ProposalParameters
+        const SetValidatorCountProposalParameters: ProposalParameters<T::BlockNumber, BalanceOf<T>> = T::SetValidatorCountProposalParameters::get();
+
         /// Exports max allowed text proposal length const.
         const TextProposalMaxLength: u32 = T::TextProposalMaxLength::get();
 


### PR DESCRIPTION
Add a `SetValidatorCountProposalParameters` const to proposals codex module.
This is both convenient in general, and also as an early way to directly test the node if it has bad JSON configuration.